### PR TITLE
Fix Inflector deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,40 +4,48 @@ language: php
 
 matrix:
   include:
-    - php: 5.4.45
-      env: DB=mysql DB_IMAGE=mysql:5.5    VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
-    - php: 5.5.38
-      env: DB=mysql DB_IMAGE=mysql:5.5    VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
-    - php: 5.6.30
-      env: DB=mysql DB_IMAGE=mysql:5.7    VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
-    - php: 7.0.21
+    - php: 7.0.32
       env: DB=mysql DB_IMAGE=mysql:8.0.3  VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
-    - php: 7.1.7
+    - php: 7.1.32
+      env: DB=mysql DB_IMAGE=mysql:8.0.3  VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
+    - php: 7.2.34
+      env: DB=mysql DB_IMAGE=mysql:8.0.3  VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
+    - php: 7.3.25
+      env: DB=mysql DB_IMAGE=mysql:8.0.3  VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
+    - php: 7.4.13
       env: DB=mysql DB_IMAGE=mysql:8.0.3  VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
 
-    - php: 5.4.45
-      env: DB=mysql DB_IMAGE=mariadb:5.5  VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
-    - php: 5.6.30
-      env: DB=mysql DB_IMAGE=mariadb:10.0 VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
-    - php: 7.1.7
+    - php: 7.0.32
+      env: DB=mysql DB_IMAGE=mariadb:10.1 VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
+    - php: 7.1.32
+      env: DB=mysql DB_IMAGE=mariadb:10.1 VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
+    - php: 7.2.34
+      env: DB=mysql DB_IMAGE=mariadb:10.1 VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
+    - php: 7.3.25
+      env: DB=mysql DB_IMAGE=mariadb:10.1 VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
+    - php: 7.4.13
       env: DB=mysql DB_IMAGE=mariadb:10.1 VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
 
-    - php: 5.4.45
-      env: DB=mysql DB_IMAGE=percona:5.5  VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
-    - php: 5.6.30
-      env: DB=mysql DB_IMAGE=percona:5.6  VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
-    - php: 7.1.7
+    - php: 7.0.32
+      env: DB=mysql DB_IMAGE=percona:5.7  VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
+    - php: 7.1.32
+      env: DB=mysql DB_IMAGE=percona:5.7  VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
+    - php: 7.2.34
+      env: DB=mysql DB_IMAGE=percona:5.7  VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
+    - php: 7.3.25
+      env: DB=mysql DB_IMAGE=percona:5.7  VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
+    - php: 7.4.13
       env: DB=mysql DB_IMAGE=percona:5.7  VARS='-p 33060:3306 -e MYSQL_PASSWORD=travis -e MYSQL_DATABASE=doctrine_extensions_tests -e MYSQL_USER=travis -e MYSQL_ALLOW_EMPTY_PASSWORD=yes'
 
-    - php: 5.4.45
-      env: DB=pgsql DB_IMAGE=postgres:9.2 VARS='-p 54320:5432 -e POSTGRES_DB=doctrine_extensions_tests -e POSTGRES_USER=travis -e POSTGRES_PASSWORD=travis'
-    - php: 5.5.38
-      env: DB=pgsql DB_IMAGE=postgres:9.3 VARS='-p 54320:5432 -e POSTGRES_DB=doctrine_extensions_tests -e POSTGRES_USER=travis -e POSTGRES_PASSWORD=travis'
-    - php: 5.6.30
-      env: DB=pgsql DB_IMAGE=postgres:9.4 VARS='-p 54320:5432 -e POSTGRES_DB=doctrine_extensions_tests -e POSTGRES_USER=travis -e POSTGRES_PASSWORD=travis'
-    - php: 7.0.21
+    - php: 7.0.32
       env: DB=pgsql DB_IMAGE=postgres:9.5 VARS='-p 54320:5432 -e POSTGRES_DB=doctrine_extensions_tests -e POSTGRES_USER=travis -e POSTGRES_PASSWORD=travis'
-    - php: 7.1.7
+    - php: 7.1.32
+      env: DB=pgsql DB_IMAGE=postgres:9.6 VARS='-p 54320:5432 -e POSTGRES_DB=doctrine_extensions_tests -e POSTGRES_USER=travis -e POSTGRES_PASSWORD=travis'
+    - php: 7.2.34
+      env: DB=pgsql DB_IMAGE=postgres:9.6 VARS='-p 54320:5432 -e POSTGRES_DB=doctrine_extensions_tests -e POSTGRES_USER=travis -e POSTGRES_PASSWORD=travis'
+    - php: 7.3.25
+      env: DB=pgsql DB_IMAGE=postgres:9.6 VARS='-p 54320:5432 -e POSTGRES_DB=doctrine_extensions_tests -e POSTGRES_USER=travis -e POSTGRES_PASSWORD=travis'
+    - php: 7.4.13
       env: DB=pgsql DB_IMAGE=postgres:9.6 VARS='-p 54320:5432 -e POSTGRES_DB=doctrine_extensions_tests -e POSTGRES_USER=travis -e POSTGRES_PASSWORD=travis'
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=7.0.0",
         "doctrine/orm": ">=2.2.3"
     },
     "require-dev": {

--- a/src/Oro/ORM/Query/AST/FunctionFactory.php
+++ b/src/Oro/ORM/Query/AST/FunctionFactory.php
@@ -11,7 +11,7 @@ use Oro\ORM\Query\AST\Platform\Functions\PlatformFunctionNode;
 class FunctionFactory
 {
     /**
-     * @var Inflector
+     * @var Inflector|null
      */
     private static $inflector;
 
@@ -46,17 +46,17 @@ class FunctionFactory
     }
 
     /**
-     * @param string $platformName
+     * @param string $word
      * @return string
      */
-    private static function classify($platformName)
+    private static function classify($word)
     {
         if (class_exists(Inflector::class)) {
             if (!self::$inflector) {
                 self::$inflector = InflectorFactory::create()->build();
             }
-            return self::$inflector->classify($platformName);
+            return self::$inflector->classify($word);
         }
-        return LegacyInflector::classify($platformName);
+        return LegacyInflector::classify($word);
     }
 }


### PR DESCRIPTION
Deprecation: The "Doctrine\Common\Inflector\Inflector::classify" method is deprecated and will be dropped in doctrine/inflector 2.0. Please update to the new Inflector API.

1. updating min PHP version to 7.0 since Doctrine Inflector (old and new one) is using parameter types (like `string`) so it's needed anyway
2. using new Inflector API if possible (from Inflector >= 1.4.0)