### PR TITLE
Add support for big integers to CAST function

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Available functions:
 * `ROUND(value, ?precision)` - Rounds the value to the specified precision (defaults to 0 precision if not specified).
 * `CEIL(value)` - Returns the value rounded up.
 * `SIGN(expr)` - Returns the sign of the argument.
-* `CAST(expr as type)` - Takes an expression of any type and produces a result value of a specified type. Supported types are: `char`, `string`, `text`, `date`, `datetime`, `time`, `int`, `integer`, `decimal`, `boolean`, `binary`.
+* `CAST(expr as type)` - Takes an expression of any type and produces a result value of a specified type. Supported types are: `char`, `string`, `text`, `date`, `datetime`, `time`, `int`, `integer`, `bigint`, `decimal`, `boolean`, `binary`.
 * `CONCAT_WS` - Concatenate all but the first argument. The first argument is used as the separator string.
 * `GROUP_CONCAT` - Returns a concatenated string. GROUP_CONCAT full syntax:
 ```

--- a/src/Oro/ORM/Query/AST/Functions/Cast.php
+++ b/src/Oro/ORM/Query/AST/Functions/Cast.php
@@ -21,6 +21,7 @@ class Cast extends AbstractPlatformAwareFunctionNode
         'time',
         'int',
         'integer',
+        'bigint',
         'decimal',
         'json',
         'bool',

--- a/src/Oro/ORM/Query/AST/Platform/Functions/Mysql/Cast.php
+++ b/src/Oro/ORM/Query/AST/Platform/Functions/Mysql/Cast.php
@@ -24,6 +24,8 @@ class Cast extends PlatformFunctionNode
             $type = 'char';
         } elseif ($type === 'int' || $type === 'integer' || $isBoolean) {
             $type = 'signed';
+        } elseif ($type === 'bigint') {
+            $type = 'unsigned';
         }
 
         $expression = 'CAST(' . $this->getExpressionValue($value, $sqlWalker) . ' AS ' . $type . ')';

--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/mysql/cast.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/mysql/cast.yml
@@ -21,6 +21,14 @@
   expectedResult:
       - 123
 
+#BIGINT
+- functions:
+    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
+  dql: "SELECT CAST('9223372036854775807' as bigint) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST('9223372036854775807' AS unsigned) AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1"
+  expectedResult:
+      - 9223372036854775807
+
 #CHAR
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }

--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/cast.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/cast.yml
@@ -21,6 +21,14 @@
   expectedResult:
       - 123
 
+#BIGINT
+- functions:
+    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
+  dql: "SELECT CAST('9223372036854775807' as bigint) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST('9223372036854775807' AS bigint) AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1"
+  expectedResult:
+      - 9223372036854775807
+
 #CHAR
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }


### PR DESCRIPTION
Dear maintainers,

I've figured the CAST function does not support big int (or unsigned integers).
I hope these changes could cover it.

Happy holidays!

For reference,
https://dev.mysql.com/doc/refman/5.6/en/cast-functions.html
https://dev.mysql.com/doc/refman/5.7/en/cast-functions.html
https://dev.mysql.com/doc/refman/8.0/en/cast-functions.html
https://www.postgresql.org/docs/12/sql-expressions.html#SQL-SYNTAX-TYPE-CASTS
https://www.postgresql.org/docs/9.1/datatype-numeric.html