### PR TITLE
Fix convert_tz function in Postgresql

### DIFF
--- a/src/Oro/ORM/Query/AST/Platform/Functions/Postgresql/ConvertTz.php
+++ b/src/Oro/ORM/Query/AST/Platform/Functions/Postgresql/ConvertTz.php
@@ -22,7 +22,7 @@ class ConvertTz extends PlatformFunctionNode
         return '"timestamp"('
             . $this->getExpressionValue($value, $sqlWalker)
             . ')'
-            . ' AT TIME ZONE ' . $this->getExpressionValue($toTz, $sqlWalker)
-            . ' AT TIME ZONE ' . $this->getExpressionValue($fromTz, $sqlWalker);
+            . ' AT TIME ZONE ' . $this->getExpressionValue($fromTz, $sqlWalker)
+            . ' AT TIME ZONE ' . $this->getExpressionValue($toTz, $sqlWalker);
     }
 }

--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/mysql/convert_tz.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/mysql/convert_tz.yml
@@ -1,16 +1,16 @@
 - functions:
     - { name: "convert_tz", className: "Oro\\ORM\\Query\\AST\\Functions\\DateTime\\ConvertTz", type: "datetime" }
-  dql: "SELECT CONVERT_TZ(f.createdAt, '+00:00', '+01:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: "SELECT CONVERT_TZ(t0_.created_at, '+00:00', '+01:00') AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1"
+  dql: "SELECT CONVERT_TZ(f.createdAt, 'UTC', 'Europe/Kiev') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CONVERT_TZ(t0_.created_at, 'UTC', 'Europe/Kiev') AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1"
   expectedResult:
-      - "2014-01-04 06:06:07"
+      - "2014-01-04 07:06:07"
 
 - functions:
     - { name: "convert_tz", className: "Oro\\ORM\\Query\\AST\\Functions\\DateTime\\ConvertTz", type: "datetime" }
-  dql: "SELECT CONVERT_TZ('2014-01-01 00:00:00', '+00:00', '+01:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: "SELECT CONVERT_TZ('2014-01-01 00:00:00', '+00:00', '+01:00') AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1"
+  dql: "SELECT CONVERT_TZ('2014-01-01 00:00:00', 'UTC', 'Europe/Kiev') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CONVERT_TZ('2014-01-01 00:00:00', 'UTC', 'Europe/Kiev') AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1"
   expectedResult:
-      - "2014-01-01 01:00:00"
+      - "2014-01-01 02:00:00"
 
 - functions:
     - { name: "convert_tz", className: "Oro\\ORM\\Query\\AST\\Functions\\DateTime\\ConvertTz", type: "datetime" }
@@ -21,7 +21,7 @@
 
 - functions:
     - { name: "convert_tz", className: "Oro\\ORM\\Query\\AST\\Functions\\DateTime\\ConvertTz", type: "datetime" }
-  dql: "SELECT CONVERT_TZ('2014-01-01 00:00:00', '+01:00', '+03:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CONVERT_TZ('2014-01-01 00:00:00', '+01:00', '+03:00') AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1
+  dql: "SELECT CONVERT_TZ('2014-01-01 00:00:00', 'Europe/Kiev', 'Asia/Baku') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT CONVERT_TZ('2014-01-01 00:00:00', 'Europe/Kiev', 'Asia/Baku') AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - "2014-01-01 02:00:00"

--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/convert_tz.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/convert_tz.yml
@@ -1,14 +1,14 @@
 - functions:
     - { name: "convert_tz", className: "Oro\\ORM\\Query\\AST\\Functions\\DateTime\\ConvertTz", type: "datetime" }
   dql: "SELECT CONVERT_TZ(f.createdAt, '+00:00', '+01:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT "timestamp"(t0_.created_at) AT TIME ZONE '+01:00' AT TIME ZONE '+00:00' AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1
+  sql: SELECT "timestamp"(t0_.created_at) AT TIME ZONE '+00:00' AT TIME ZONE '+01:00' AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - "2014-01-04 06:06:07"
 
 - functions:
     - { name: "convert_tz", className: "Oro\\ORM\\Query\\AST\\Functions\\DateTime\\ConvertTz", type: "datetime" }
   dql: "SELECT CONVERT_TZ('2014-01-01 00:00:00', '+00:00', '+01:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT "timestamp"('2014-01-01 00:00:00') AT TIME ZONE '+01:00' AT TIME ZONE '+00:00' AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1
+  sql: SELECT "timestamp"('2014-01-01 00:00:00') AT TIME ZONE '+00:00' AT TIME ZONE '+01:00' AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - "2014-01-01 01:00:00"
 
@@ -22,6 +22,6 @@
 - functions:
     - { name: "convert_tz", className: "Oro\\ORM\\Query\\AST\\Functions\\DateTime\\ConvertTz", type: "datetime" }
   dql: "SELECT CONVERT_TZ('2014-01-01 00:00:00', '+01:00', '+03:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT "timestamp"('2014-01-01 00:00:00') AT TIME ZONE '+03:00' AT TIME ZONE '+01:00' AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1
+  sql: SELECT "timestamp"('2014-01-01 00:00:00') AT TIME ZONE '+01:00' AT TIME ZONE '+03:00' AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - "2014-01-01 02:00:00"

--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/convert_tz.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/convert_tz.yml
@@ -1,16 +1,23 @@
 - functions:
     - { name: "convert_tz", className: "Oro\\ORM\\Query\\AST\\Functions\\DateTime\\ConvertTz", type: "datetime" }
-  dql: "SELECT CONVERT_TZ(f.createdAt, '+00:00', '+01:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT "timestamp"(t0_.created_at) AT TIME ZONE '+00:00' AT TIME ZONE '+01:00' AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1
+  dql: "SELECT CONVERT_TZ(f.createdAt, '+00:00', '+02:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT "timestamp"(t0_.created_at) AT TIME ZONE '+00:00' AT TIME ZONE '+02:00' AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
-      - "2014-01-04 06:06:07"
+      - "2014-01-04 03:06:07"
 
 - functions:
     - { name: "convert_tz", className: "Oro\\ORM\\Query\\AST\\Functions\\DateTime\\ConvertTz", type: "datetime" }
-  dql: "SELECT CONVERT_TZ('2014-01-01 00:00:00', '+00:00', '+01:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT "timestamp"('2014-01-01 00:00:00') AT TIME ZONE '+00:00' AT TIME ZONE '+01:00' AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1
+  dql: "SELECT CONVERT_TZ('2014-01-01 00:00:00', '+00:00', '+02:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT "timestamp"('2014-01-01 00:00:00') AT TIME ZONE '+00:00' AT TIME ZONE '+02:00' AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
-      - "2014-01-01 01:00:00"
+      - "2013-12-31 22:00:00"
+
+- functions:
+    - { name: "convert_tz", className: "Oro\\ORM\\Query\\AST\\Functions\\DateTime\\ConvertTz", type: "datetime" }
+  dql: "SELECT CONVERT_TZ('2014-01-01 00:00:00', 'UTC', 'Europe/Kiev') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT "timestamp"('2014-01-01 00:00:00') AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Kiev' AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - "2014-01-01 02:00:00"
 
 - functions:
     - { name: "convert_tz", className: "Oro\\ORM\\Query\\AST\\Functions\\DateTime\\ConvertTz", type: "datetime" }
@@ -21,7 +28,7 @@
 
 - functions:
     - { name: "convert_tz", className: "Oro\\ORM\\Query\\AST\\Functions\\DateTime\\ConvertTz", type: "datetime" }
-  dql: "SELECT CONVERT_TZ('2014-01-01 00:00:00', '+01:00', '+03:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT "timestamp"('2014-01-01 00:00:00') AT TIME ZONE '+01:00' AT TIME ZONE '+03:00' AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1
+  dql: "SELECT CONVERT_TZ('2014-01-01 00:00:00', 'Europe/Kiev', 'Asia/Baku') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT "timestamp"('2014-01-01 00:00:00') AT TIME ZONE 'Europe/Kiev' AT TIME ZONE 'Asia/Baku' AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - "2014-01-01 02:00:00"

--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/convert_tz.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/convert_tz.yml
@@ -1,5 +1,12 @@
 - functions:
     - { name: "convert_tz", className: "Oro\\ORM\\Query\\AST\\Functions\\DateTime\\ConvertTz", type: "datetime" }
+  dql: "SELECT CONVERT_TZ(f.createdAt, 'UTC', 'Europe/Kiev') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT "timestamp"(t0_.created_at) AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Kiev' AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - "2014-01-04 07:06:07"
+
+- functions:
+    - { name: "convert_tz", className: "Oro\\ORM\\Query\\AST\\Functions\\DateTime\\ConvertTz", type: "datetime" }
   dql: "SELECT CONVERT_TZ('2014-01-01 00:00:00', 'UTC', 'Europe/Kiev') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
   sql: SELECT "timestamp"('2014-01-01 00:00:00') AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Kiev' AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:

--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/convert_tz.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/convert_tz.yml
@@ -1,19 +1,5 @@
 - functions:
     - { name: "convert_tz", className: "Oro\\ORM\\Query\\AST\\Functions\\DateTime\\ConvertTz", type: "datetime" }
-  dql: "SELECT CONVERT_TZ(f.createdAt, '+00:00', '+02:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT "timestamp"(t0_.created_at) AT TIME ZONE '+00:00' AT TIME ZONE '+02:00' AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1
-  expectedResult:
-      - "2014-01-04 03:06:07"
-
-- functions:
-    - { name: "convert_tz", className: "Oro\\ORM\\Query\\AST\\Functions\\DateTime\\ConvertTz", type: "datetime" }
-  dql: "SELECT CONVERT_TZ('2014-01-01 00:00:00', '+00:00', '+02:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT "timestamp"('2014-01-01 00:00:00') AT TIME ZONE '+00:00' AT TIME ZONE '+02:00' AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1
-  expectedResult:
-      - "2013-12-31 22:00:00"
-
-- functions:
-    - { name: "convert_tz", className: "Oro\\ORM\\Query\\AST\\Functions\\DateTime\\ConvertTz", type: "datetime" }
   dql: "SELECT CONVERT_TZ('2014-01-01 00:00:00', 'UTC', 'Europe/Kiev') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
   sql: SELECT "timestamp"('2014-01-01 00:00:00') AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Kiev' AS sclr_0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:


### PR DESCRIPTION
`$toTz` parameter was passed before `$fromTz`. It causes `convert_tz` function to work not as expected. This pr fixes this bug.