### PR TITLE
chore: Autorize doctrine/dbal v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": ">=8.1",
-        "doctrine/orm": ">=2.6",
-        "doctrine/dbal": ">=2.6"
+        "doctrine/orm": "~2.6",
+        "doctrine/dbal": "~2.6|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~10",


### PR DESCRIPTION
The last version (2.0.3) is not installed because you don't autorize dbal v3.