### PR TITLE
Set requirement for doctrine/lexer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,9 @@
     ],
     "require": {
         "php": ">=8.1",
-        "doctrine/orm": "~2.6",
-        "doctrine/dbal": "~2.6|~3.0"
+        "doctrine/lexer": "~1.0|~2.0",
+        "doctrine/orm": "~2.8",
+        "doctrine/dbal": "~2.10|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~10",


### PR DESCRIPTION
The doctrine/lexer 3 is incompatible but doctrine/orm 2.18 will be using it. The doctrine/lexer was not used before 2.10 of the orm which requires dbal 2.10 that is why that requirements also.  Before lexer was part of the old doctrine/common before the lexer got in its own package.

See also: https://github.com/doctrine/orm/issues/11192

