### PR TITLE
Still support the latest older versions of doctrines orm 2, dbal 3 and lexer 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.1, 8.2, 8.3]
+        php: [8.1, 8.2, 8.3, 8.4]
         db_image_name: [mysql, percona, postgres]
         composer-flags: ['', '--prefer-lowest']
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,10 @@ jobs:
           composer self-update
           composer update --prefer-dist --optimize-autoloader --no-interaction --no-suggest ${{ matrix.composer-flags }}
 
+      - name: Check lowest dependencies
+        run: php tests/lowest-dependencies.php
+        if: ${{ matrix.composer-flags == '--prefer-lowest' }}
+
       - name: Run setup tests
         run: vendor/bin/phpunit --configuration tests/config/${{ matrix.db }}.phpunit.xml tests/Oro/Tests/Connection/SetupTest.php
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.1]
+        php: [8.1, 8.2, 8.3]
         db_image_name: [mysql, percona, postgres]
+        composer-flags: ['', '--prefer-lowest']
         include:
           - db_image_name: mysql
             db_image_version: 8
@@ -51,7 +52,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer self-update
-          composer install --prefer-dist --optimize-autoloader --no-interaction --no-suggest
+          composer update --prefer-dist --optimize-autoloader --no-interaction --no-suggest ${{ matrix.composer-flags }}
 
       - name: Run setup tests
         run: vendor/bin/phpunit --configuration tests/config/${{ matrix.db }}.phpunit.xml tests/Oro/Tests/Connection/SetupTest.php
@@ -61,6 +62,7 @@ jobs:
 
       - name: Check code style
         run: vendor/bin/phpcs src/ tests/ -p --encoding=utf-8 --extensions=php --standard=psr2
+        if: ${{ matrix.composer-flags != '--prefer-lowest' }}
 
       - name: Tear down tests
         run: vendor/bin/phpunit --configuration tests/config/${{ matrix.db }}.phpunit.xml tests/Oro/Tests/Connection/TearDownTest.php

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ phpunit.xml
 vendor/
 composer.lock
 .idea/
+.phpunit.cache/

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~10",
-        "doctrine/data-fixtures": "^1.3",
+        "doctrine/data-fixtures": "^1.6",
         "symfony/yaml": "5.*",
         "symfony/cache": "5.*",
-        "squizlabs/php_codesniffer": "^3.5",
+        "squizlabs/php_codesniffer": "3.9.*",
         "doctrine/annotations": "^1.14|^2.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,17 +13,17 @@
     ],
     "require": {
         "php": ">=8.1",
-        "doctrine/lexer": "~3.0",
-        "doctrine/orm": "~3.0",
-        "doctrine/dbal": "~3.0|~4.0"
+        "doctrine/lexer": "^2.0|^3.0",
+        "doctrine/orm": "^2.19|^3.0",
+        "doctrine/dbal": "^3.3|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~10",
         "doctrine/data-fixtures": "^1.3",
         "symfony/yaml": "5.*",
         "symfony/cache": "5.*",
-        "squizlabs/php_codesniffer": "3.9.*",
-        "doctrine/annotations": "~2.0"
+        "squizlabs/php_codesniffer": "^3.5",
+        "doctrine/annotations": "^1.14|^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     "require-dev": {
         "phpunit/phpunit": "~10",
         "doctrine/data-fixtures": "^1.6",
-        "symfony/yaml": "5.*",
-        "symfony/cache": "5.*",
+        "symfony/yaml": "^5|^6|^7",
+        "symfony/cache": "^5|^6|^7",
         "squizlabs/php_codesniffer": "3.9.*",
         "doctrine/annotations": "^1.14|^2.0"
     },

--- a/tests/lowest-dependencies.php
+++ b/tests/lowest-dependencies.php
@@ -1,0 +1,41 @@
+<?php
+
+$content = file_get_contents(dirname(__DIR__) . '/composer.lock');
+
+$dependencies = json_decode($content, true, \JSON_THROW_ON_ERROR);
+
+$expectedDependencies = [
+    'doctrine/annotations' => '1.14.0',
+    'doctrine/lexer' => '2.0.0',
+    'doctrine/dbal' => '3.3.6',
+    'doctrine/orm' => '2.19.0',
+];
+
+foreach ($expectedDependencies as $expectedDependency => $expectedVersion) {
+    $dependency = null;
+    foreach ([...$dependencies['packages'], ...$dependencies['packages-dev']] as $package) {
+        if ($package['name'] === $expectedDependency) {
+            $dependency = $package;
+            break;
+        }
+    }
+
+    if (null === $dependency) {
+        throw new RuntimeException('Missing dependency: ' . $expectedDependency);
+    }
+
+    $dependencyVersion = $dependency['version'];
+
+    if ($dependencyVersion !== $expectedVersion) {
+        throw new RuntimeException(
+            sprintf(
+                "Invalid version for %s. Expected: %s. Found: %s",
+                $expectedDependency,
+                $expectedVersion,
+                $dependencyVersion
+            )
+        );
+    }
+}
+
+echo 'All dependencies are correct.' . \PHP_EOL;


### PR DESCRIPTION
After lexer 3 support is merged. I rebased this branch to keep support for older doctrine versions.

# TODO

- [x] Run tests?