### PR TITLE
Add lexer 3 support to 2.x branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=8.0",
         "doctrine/orm": ">=2.6, <3.0",
         "doctrine/dbal": ">=2.6, <3.0",
-        "doctrine/lexer": "^2, <3"
+        "doctrine/lexer": "^2|^3"
     },
     "require-dev": {
         "phpunit/phpunit": "9.*",
@@ -23,7 +23,7 @@
         "symfony/yaml": "5.*",
         "symfony/cache": "5.*",
         "squizlabs/php_codesniffer": "3.5.*",
-        "doctrine/annotations": ">1.0, <2.0"
+        "doctrine/annotations": "^1.0|^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Oro/ORM/Query/AST/Functions/Cast.php
+++ b/src/Oro/ORM/Query/AST/Functions/Cast.php
@@ -40,7 +40,7 @@ class Cast extends AbstractPlatformAwareFunctionNode
 
         $parser->match(Lexer::T_IDENTIFIER);
         $lexer = $parser->getLexer();
-        $type = $lexer->token['value'];
+        $type = $lexer->token->value;
 
         if ($lexer->isNextToken(Lexer::T_OPEN_PARENTHESIS)) {
             $parser->match(Lexer::T_OPEN_PARENTHESIS);

--- a/src/Oro/ORM/Query/AST/Functions/Numeric/Round.php
+++ b/src/Oro/ORM/Query/AST/Functions/Numeric/Round.php
@@ -20,7 +20,7 @@ class Round extends AbstractPlatformAwareFunctionNode
         $this->parameters[self::VALUE] = $parser->SimpleArithmeticExpression();
 
         // parse second parameter if available
-        if (Lexer::T_COMMA === $lexer->lookahead['type']) {
+        if (Lexer::T_COMMA === $lexer->lookahead->type) {
             $parser->match(Lexer::T_COMMA);
             $this->parameters[self::PRECISION] = $parser->ArithmeticPrimary();
         }

--- a/src/Oro/ORM/Query/AST/Functions/Numeric/TimestampDiff.php
+++ b/src/Oro/ORM/Query/AST/Functions/Numeric/TimestampDiff.php
@@ -35,7 +35,7 @@ class TimestampDiff extends AbstractPlatformAwareFunctionNode
         $parser->match(Lexer::T_IDENTIFIER);
 
         $lexer = $parser->getLexer();
-        $unit = strtoupper(trim($lexer->token['value']));
+        $unit = strtoupper(trim($lexer->token->value));
         if (!$this->isSupportedUnit($unit)) {
             $parser->syntaxError(
                 \sprintf(

--- a/src/Oro/ORM/Query/AST/Functions/String/GroupConcat.php
+++ b/src/Oro/ORM/Query/AST/Functions/String/GroupConcat.php
@@ -43,7 +43,7 @@ class GroupConcat extends AbstractPlatformAwareFunctionNode
         }
 
         if ($lexer->isNextToken(Lexer::T_IDENTIFIER)) {
-            if (\strtolower($lexer->lookahead['value']) !== 'separator') {
+            if (\strtolower($lexer->lookahead->value) !== 'separator') {
                 $parser->syntaxError('separator');
             }
             $parser->match(Lexer::T_IDENTIFIER);


### PR DESCRIPTION
This make it backports the lexer 3 support to 2.x branch to support too keep the supported verson constraint of 2.x branch as wide as possible.