### PR TITLE
Add branch alias for master to 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,11 @@
             "Oro\\ORM\\": "src/Oro/ORM"
         }
     },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.x-dev"
+        }
+    },
     "prefer-stable": true,
     "minimum-stability": "stable"
 }


### PR DESCRIPTION
This will composer tell if somebody installs `^3@dev` that it should install master branch of this repository.

Another option is just "rename" the branch to something like `3.0` then branch alias are not required and don't need to be keep in sync.

Currently it seems there is already a `3.x` branch which is kind of outdated: https://github.com/oroinc/doctrine-extensions/compare/3.x...master I recommend remove that one and rename `master` to `3.0` close this PR. This helps composer best to detect correct dev versions.