### PR TITLE
Fix MariaDB compatibility with DBAL 4

### DIFF
--- a/src/Oro/ORM/Query/AST/FunctionFactory.php
+++ b/src/Oro/ORM/Query/AST/FunctionFactory.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Oro\ORM\Query\AST;
 
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\Query\QueryException;
 use Oro\ORM\Query\AST\Platform\Functions\PlatformFunctionNode;
@@ -23,7 +23,7 @@ class FunctionFactory
     ): PlatformFunctionNode {
         if ($platform instanceof PostgreSQLPlatform) {
             $platformName = 'postgresql';
-        } elseif ($platform instanceof MySQLPlatform) {
+        } elseif ($platform instanceof AbstractMySQLPlatform) {
             $platformName = 'mysql';
         } else {
             throw QueryException::syntaxError(


### PR DESCRIPTION
This PR fixes an issue where MariaDB was not working when using doctrine-extensions with DBAL 4. The problem occurred because since DBAL 4, `MariaDBPlatform` no longer extends `MySQLPlatform` but extends `AbstractMySQLPlatform` instead.

The fix updates the platform check in `FunctionFactory.php` to use `AbstractMySQLPlatform` instead of `MySQLPlatform`. This change maintains compatibility with DBAL 3 (where `MySQLPlatform` already extends from `AbstractMySQLPlatform`) while adding support for DBAL 4 and MariaDB.

Changes:
- Replace `MySQLPlatform` check with `AbstractMySQLPlatform` in platform detection
- Update imports accordingly

Fixes the error:
[Syntax Error] Not supported platform "Doctrine\DBAL\Platforms\MariaDB1052Platform"