### PR TITLE
Allow install of doctrine/dbal 4 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "doctrine/orm": "^3.0"
+        "doctrine/orm": "^3.0 || ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~10",


### PR DESCRIPTION
There seems to be no changes required to support also the dbal 4 version.